### PR TITLE
fix: Add TinyTeX for PDF rendering in guidebook

### DIFF
--- a/.github/workflows/render-simple.yml
+++ b/.github/workflows/render-simple.yml
@@ -32,10 +32,14 @@ jobs:
         run: |
           python3 -m pip install jupyter nbformat nbclient
 
-      - name: Render Website (HTML only, skip PDFs)
+      - name: Install TinyTeX (needed for PDF rendering)
+        run: |
+          quarto install tinytex
+
+      - name: Render Website
         run: |
           cd website
-          quarto render --to html
+          quarto render
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3

--- a/.github/workflows/render-simple.yml
+++ b/.github/workflows/render-simple.yml
@@ -32,14 +32,10 @@ jobs:
         run: |
           python3 -m pip install jupyter nbformat nbclient
 
-      - name: Install TinyTeX (needed for PDF rendering)
-        run: |
-          quarto install tinytex
-
-      - name: Render Website
+      - name: Render Website (HTML only, skip PDFs)
         run: |
           cd website
-          quarto render
+          quarto render --to html
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3

--- a/.github/workflows/render-simple.yml
+++ b/.github/workflows/render-simple.yml
@@ -32,6 +32,10 @@ jobs:
         run: |
           python3 -m pip install jupyter nbformat nbclient
 
+      - name: Install TinyTeX (needed for PDF rendering)
+        run: |
+          quarto install tinytex
+
       - name: Render Website
         run: |
           cd website


### PR DESCRIPTION
The guidebook/guest-guidebook-2024.qmd renders to PDF format. Added TinyTeX installation to support PDF output.

Error was: 'No TeX installation was detected'

🐛 Generated with Claude Code