### PR TITLE
fix: Include main.css to fix homepage padding and layout

### DIFF
--- a/website/_quarto.yml
+++ b/website/_quarto.yml
@@ -8,6 +8,7 @@ project:
     - "images/"
     - "raw_documents/"
     - "scripts/"
+    - "styles/"
 
 website:
   title: "The Rittenhouse Residence"

--- a/website/index.qmd
+++ b/website/index.qmd
@@ -5,6 +5,7 @@ description: "Book 1822 Pine Street - a meticulously preserved 1854 mansion near
 page-layout: custom
 toc: false
 css:
+  - styles/main.css
   - styles/homepage.css
   - styles/animations.css
 include-after-body:


### PR DESCRIPTION
CRITICAL FIX - Previous changes weren't taking effect!

The Issue:
- main.css was created but NOT included in index.qmd
- Quarto only loads CSS files explicitly listed in frontmatter
- Result: padding fixes and layout overrides never applied

The Fix:
- Added styles/main.css to index.qmd CSS list (MUST be first!)
- Added styles/ to _quarto.yml resources
- Ensures Quarto container padding overrides load before other CSS
- Now homepage will have proper padding and full-width layout

This completes the homepage fixes:
1. ✅ Lighter overlay (0.05/0.15/0.25) - image now visible
2. ✅ Stronger text shadows - readable against light overlay
3. ✅ main.css NOW LOADS - fixes edge padding issues

Changes will take effect on next build.